### PR TITLE
Update mqtt_plugin.py

### DIFF
--- a/Tsai/plugin/mqtt_plugin.py
+++ b/Tsai/plugin/mqtt_plugin.py
@@ -3,7 +3,7 @@ import json
 import base64
 from waggle.plugin import Plugin
 import os
-os.environ["PYWAGGLE_LOG_DIR"] = "/home/pi/code/test-run-logs"
+os.environ["PYWAGGLE_LOG_DIR"] = "/var/log/pywaggle"
 
 types = {
     "t": "env.temperature",


### PR DESCRIPTION
Placing the log directory in the standard location for Debian logging.  The /var/log/pywaggle directory will need to be created with appropriate permissions during installation of this program.